### PR TITLE
Fixes issues with Swagger URL being unable to reach

### DIFF
--- a/ShoeCompany/ShoeCompany.csproj
+++ b/ShoeCompany/ShoeCompany.csproj
@@ -4,6 +4,9 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <UserSecretsId>54abb132-3324-4981-b77e-3743324e9e32</UserSecretsId>
+    <EnvironmentVariables>
+      <NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY>2,1000</NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY>
+    </EnvironmentVariables>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/setup.sh
+++ b/setup.sh
@@ -12,23 +12,28 @@ git config --global user.name "$GIT_USERNAME"
 git config --global user.email "$GIT_EMAIL"
 
 
-RESOURCE_GROUP=$(az group list --query "[0].name" -o tsv)
+RESOURCE_GROUP=az-mslearn-apim-$RANDOM
+
+#Create Resource Group
+printf "\nCreating Resource Group ... (2/7)\n\n"
+
+az group create --name $RESOURCE_GROUP --location centralus
 
 # Create App Service plan
 PLAN_NAME=myPlan
 
 
-printf "\nCreating App Service plan in FREE tier ... (2/7)\n\n"
+printf "\nCreating App Service plan in FREE tier ... (3/7)\n\n"
 
 
 az appservice plan create --name $apiappname --resource-group $RESOURCE_GROUP --sku FREE --location centralus --verbose
 
-printf "\nCreating API App ... (3/7)\n\n"
+printf "\nCreating API App ... (4/7)\n\n"
 
 az webapp create --name $apiappname --resource-group $RESOURCE_GROUP --plan $apiappname --deployment-local-git --verbose
 
 
-printf "\nSetting the account-level deployment credentials ...(4/7)\n\n"
+printf "\nSetting the account-level deployment credentials ...(5/7)\n\n"
 
 
 DEPLOY_USER="myName1$(openssl rand -hex 5)"
@@ -45,19 +50,19 @@ REMOTE_NAME=production
 
 
 # Set remote on src
-printf "\nSetting Git remote...(5/7)\n\n"
+printf "\nSetting Git remote...(6/7)\n\n"
 
 
 git remote add $REMOTE_NAME $GIT_URL
 
 
-printf "\nGit add...(6/7)\n\n"
+printf "\nGit add...(7/7)\n\n"
 
 git add .
 git commit -m "initial revision"
 
 
-printf "\nGit push... (7/7)\n\n"
+printf "\nGit push... (8/7)\n\n"
 
 
 # printf "When prompted for a password enter this: $DEPLOY_PASSWORD\n"


### PR DESCRIPTION
fixes #3

The current setup.sh shell script has two problems:
i. Whenever there are no resource groups within the azure subscription, the line below returns an empty string which results in unsuccessful deployment. 

The line:
```bash
RESOURCE_GROUP=$(az group list --query "[0].name" -o tsv)
``` 

Error caused:

```bash
fatal: unable to access 'https://ShoeCoAPIac816d0e07.scm.azurewebsites.net/ShoeCoAPIac816d0e07.git/': Could not resolve host: ShoeCoAPIac816d0e07.scm.azurewebsites.net
```

Error screenshot:
![image](https://github.com/MicrosoftDocs/mslearn-publish-manage-apis-with-azure-api-management/assets/38563175/41bfc463-ee18-4f32-b209-297a857d034e)


Fix added with this PR:

```bash
RESOURCE_GROUP=az-mslearn-apim-$RANDOM

#Create Resource Group
printf "\nCreating Resource Group ... (2/7)\n\n"

az group create --name $RESOURCE_GROUP --location centralus
```

The above fix will create a resource group in the set azure subscription and use it in the rest of the script.

ii. After adding the above fix, I encountered another issue where the script fails on the initial run but runs successfully in the second try every time.

Error Screenshot:
![image](https://github.com/MicrosoftDocs/mslearn-publish-manage-apis-with-azure-api-management/assets/38563175/4163fb88-7491-45ba-9d16-7c804711a19f)

Error Message:

```bash
remote:   Committing restore...
remote:   Generating MSBuild file C:\home\site\repository\ShoeCompany\obj\ShoeCompany.csproj.nuget.g.props.
remote:   Generating MSBuild file C:\home\site\repository\ShoeCompany\obj\ShoeCompany.csproj.nuget.g.targets.
remote:   Writing assets file to disk. Path: C:\home\site\repository\ShoeCompany\obj\project.assets.json
remote:   Restore failed in 19.94 sec for C:\home\site\repository\ShoeCompany\ShoeCompany.csproj.
remote:
remote:   NuGet Config files used:
remote:       D:\DWASFiles\Sites\#1ShoeCoAPI2b22fc5378\AppData\NuGet\NuGet.Config
remote:
remote:   Feeds used:
remote:       https://api.nuget.org/v3/index.json
remote:
remote:   Installed:
remote:       55 package(s) to C:\home\site\repository\ShoeCompany\ShoeCompany.csproj
remote: Done Building Project "C:\home\site\repository\ShoeCompany\ShoeCompany.csproj" (Restore target(s)) -- FAILED.
remote: 
remote: Build FAILED.
remote: 
remote: "C:\home\site\repository\ShoeCompany\ShoeCompany.csproj" (Restore target) (1) ->
remote: (Restore target) ->
remote:   C:\home\site\repository\ShoeCompany\ShoeCompany.csproj : error NU3028: Package 'Microsoft.AspNetCore.WebUtilities 2.0.0' from source 'https://api.nuget.org/v3/index.json': The repository primary signature's timestamp found a chain building issue: A certificate chain processed, but terminated in a root certificate which is not trusted by the trust provider.
remote:   C:\home\site\repository\ShoeCompany\ShoeCompany.csproj : error NU3028: Package 'Microsoft.AspNetCore.Authorization 2.0.0' from source 'https://api.nuget.org/v3/index.json': The repository primary signature's timestamp found a chain building issue: A certificate chain processed, but terminated in a root certificate which is not trusted by the trust provider.
remote:   C:\home\site\repository\ShoeCompany\ShoeCompany.csproj : error NU3028: Package 'Microsoft.Extensions.Hosting.Abstractions 2.0.0' from source 'https://api.nuget.org/v3/index.json': The repository primary signature's timestamp found a chain building issue: A certificate chain processed, but terminated in a root certificate which is not trusted by the trust provider.
remote:   C:\home\site\repository\ShoeCompany\ShoeCompany.csproj : error NU3028: Package 'Microsoft.Net.Http.Headers 2.0.0' from source 'https://api.nuget.org/v3/index.json': The repository primary signature's timestamp found a chain building issue: A certificate chain processed, but terminated in a root certificate which is not trusted by the trust provider.
remote:   C:\home\site\repository\ShoeCompany\ShoeCompany.csproj : error NU3028: Package 'Microsoft.AspNetCore.Http.Features 2.0.0' from source 'https://api.nuget.org/v3/index.json': The repository primary signature's timestamp found a chain building issue: A certificate chain processed, but terminated in a root certificate which is not trusted by the trust provider.
remote:   C:\home\site\repository\ShoeCompany\ShoeCompany.csproj : error NU3037: Package 'Microsoft.AspNetCore.WebUtilities 2.0.0' from source 'https://api.nuget.org/v3/index.json': The repository primary signature validity period has expired.
remote:   C:\home\site\repository\ShoeCompany\ShoeCompany.csproj : error NU3037: Package 'Microsoft.AspNetCore.Http.Features 2.0.0' from source 'https://api.nuget.org/v3/index.json': The repository primary signature validity period has expired.
remote:   C:\home\site\repository\ShoeCompany\ShoeCompany.csproj : error NU3037: Package 'Microsoft.AspNetCore.Authorization 2.0.0' from source 'https://api.nuget.org/v3/index.json': The repository primary signature validity period has expired.
remote:   C:\home\site\repository\ShoeCompany\ShoeCompany.csproj : error NU3037: Package 'Microsoft.Net.Http.Headers 2.0.0' from source 'https://api.nuget.org/v3/index.json': The repository primary signature validity period has expired.
remote:   C:\home\site\repository\ShoeCompany\ShoeCompany.csproj : error NU3037: Package 'Microsoft.Extensions.Hosting.Abstractions 2.0.0' from source 'https://api.nuget.org/v3/index.json': The repository primary signature validity period has expired.
remote:
remote:     0 Warning(s)
remote:     10 Error(s)
remote:
remote: Time Elapsed 00:00:24.09
remote: Failed exitCode=1, command="C:\Program Files (x86)\MSBuild-16.4\MSBuild\Current\Bin\MSBuild.exe" /restore "C:\home\site\repository\ShoeCompany\ShoeCompany.csproj" /p:DeployOnBuild=true /p:configuration=Release /p:publishurl="C:\local\Temp\8dc910d04ac2d9d"
remote: An error has occurred during web site deployment.
remote:
remote: Deployment Failed.
remote: Error - Changes committed to remote repository but deployment to website failed.
To https://ShoeCoAPI2b22fc5378.scm.azurewebsites.net/ShoeCoAPI2b22fc5378.git
 * [new branch]      master -> master
Setup complete!

***********************    IMPORTANT INFO  *********************

Swagger URL: https://ShoeCoAPI2b22fc5378.azurewebsites.net/swagger
Swagger JSON URL: https://shoecoapi2b22fc5378.azurewebsites.net/swagger/v1/swagger.json
```

Fix: 
After doing some research on the official Microsoft docs I found a resolution that fixes this issue, adding an environment variable that retries the build when it fails on the first try.

Docs references:
https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu3028
https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu3037
https://learn.microsoft.com/en-us/nuget/reference/signed-package-verification-options#retry-untrusted-root-failures

Added the following code in ShoeCompany/ShoeCompany.csproj file :
```bash
    <EnvironmentVariables>
      <NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY>2,1000</NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY>
    </EnvironmentVariables>
```

Now the script runs without any error directly within the first try.

