### PR TITLE
fix: enable SCM Basic Auth publishing credentials

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -27,6 +27,8 @@ printf "\nCreating API App ... (3/7)\n\n"
 
 az webapp create --name $apiappname --resource-group $RESOURCE_GROUP --plan $apiappname --deployment-local-git --verbose
 
+#Enable SCM Basic Auth Publishing Credentials
+az resource update --resource-group $RESOURCE_GROUP --name scm --namespace Microsoft.Web --resource-type basicPublishingCredentialsPolicies --parent sites/$apiappname --set properties.allow=true
 
 printf "\nSetting the account-level deployment credentials ...(4/7)\n\n"
 


### PR DESCRIPTION
## Summary
This PR fixes a failure in the deployment script caused by SCM Basic Auth publishing credentials being disabled by default when a webapp is created.

## Changes
- Added `az resource update` command to enable SCM Basic Auth after webapp creation.

## Why
Without this change, the deployment script cannot complete successfully since the subsequent steps depend on SCM Basic Auth being enabled.
